### PR TITLE
Use generic position items for Riigikogu

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,46 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: e7f6e52441ae04c6d4daf73fb5191bc68574633a
+  revision: 0cba06a671a6ff836a02a9889099045987593ff2
   specs:
     commons-builder (0.1.0)
+      commons-integrity
+      liquid
       rest-client (~> 2.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    commons-integrity (0.1)
+      activesupport
+      json
+      require_all
+    concurrent-ruby (1.0.5)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    json (2.1.0)
+    liquid (4.0.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    minitest (5.11.3)
     netrc (0.11.0)
+    require_all (2.0.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)

--- a/boundaries/index.json
+++ b/boundaries/index.json
@@ -19,7 +19,7 @@
         "associations": [
             {
                 "comment": "member of the Estonian Riigikogu",
-                "position_item_id": "Q33129158"
+                "position_item_id": "Q21100241"
             }
         ],
         "name_columns": {

--- a/config.json
+++ b/config.json
@@ -8,7 +8,6 @@
     "Q4450503"
   ],
   "hand_maintained_files": [
-    "legislative/index.json",
     "executive/index.json"
   ]
 }

--- a/executive/Q18625841/current/query-results.json
+++ b/executive/Q18625841/current/query-results.json
@@ -29,7 +29,7 @@
       "district_name_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Tallinna linn"
+        "value" : "Tallinn"
       },
       "district_name_en" : {
         "xml:lang" : "en",

--- a/executive/Q18625841/current/query-used.rq
+++ b/executive/Q18625841/current/query-used.rq
@@ -10,54 +10,65 @@ WHERE {
   VALUES ?role_superclass { wd:Q3740505 }
   BIND(wd:Q18625841 AS ?org)
   OPTIONAL {
-          ?org rdfs:label ?org_en
-          FILTER(LANG(?org_en) = "en")
-        }
+  ?org rdfs:label ?org_en
+  FILTER(LANG(?org_en) = "en")
+}
+
 OPTIONAL {
-          ?org rdfs:label ?org_et
-          FILTER(LANG(?org_et) = "et")
-        }
+  ?org rdfs:label ?org_et
+  FILTER(LANG(?org_et) = "et")
+}
+
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   OPTIONAL {
-          ?item rdfs:label ?name_en
-          FILTER(LANG(?name_en) = "en")
-        }
+  ?item rdfs:label ?name_en
+  FILTER(LANG(?name_en) = "en")
+}
+
 OPTIONAL {
-          ?item rdfs:label ?name_et
-          FILTER(LANG(?name_et) = "et")
-        }
+  ?item rdfs:label ?name_et
+  FILTER(LANG(?name_et) = "et")
+}
+
   ?statement ps:P39 ?role .
   OPTIONAL {
-          ?role rdfs:label ?role_en
-          FILTER(LANG(?role_en) = "en")
-        }
+  ?role rdfs:label ?role_en
+  FILTER(LANG(?role_en) = "en")
+}
+
 OPTIONAL {
-          ?role rdfs:label ?role_et
-          FILTER(LANG(?role_et) = "et")
-        }
+  ?role rdfs:label ?role_et
+  FILTER(LANG(?role_et) = "et")
+}
+
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_en
-          FILTER(LANG(?role_superclass_en) = "en")
-        }
+  ?role_superclass rdfs:label ?role_superclass_en
+  FILTER(LANG(?role_superclass_en) = "en")
+}
+
 OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_et
-          FILTER(LANG(?role_superclass_et) = "et")
-        }
+  ?role_superclass rdfs:label ?role_superclass_et
+  FILTER(LANG(?role_superclass_et) = "et")
+}
+
   ?role wdt:P361 ?org .
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
-          ?district rdfs:label ?district_name_en
-          FILTER(LANG(?district_name_en) = "en")
-        }
+  ?district rdfs:label ?district_name_en
+  FILTER(LANG(?district_name_en) = "en")
+}
+
 OPTIONAL {
-          ?district rdfs:label ?district_name_et
-          FILTER(LANG(?district_name_et) = "et")
-        }
+  ?district rdfs:label ?district_name_et
+  FILTER(LANG(?district_name_et) = "et")
+}
+
   }
   OPTIONAL { ?statement pq:P580 ?start }
   OPTIONAL { ?statement pq:P582 ?end }
@@ -68,13 +79,15 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
-          ?party rdfs:label ?party_name_en
-          FILTER(LANG(?party_name_en) = "en")
-        }
+  ?party rdfs:label ?party_name_en
+  FILTER(LANG(?party_name_en) = "en")
+}
+
 OPTIONAL {
-          ?party rdfs:label ?party_name_et
-          FILTER(LANG(?party_name_et) = "et")
-        }
+  ?party rdfs:label ?party_name_et
+  FILTER(LANG(?party_name_et) = "et")
+}
+
     OPTIONAL { ?party_statement pq:P582 ?end_party }
     BIND(COALESCE(?end_party, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?party_end_or_sentinel)
     FILTER(?party_end_or_sentinel >= NOW())

--- a/executive/Q2421589/current/query-used.rq
+++ b/executive/Q2421589/current/query-used.rq
@@ -10,54 +10,65 @@ WHERE {
   VALUES ?role_superclass { wd:Q737115 }
   BIND(wd:Q2421589 AS ?org)
   OPTIONAL {
-          ?org rdfs:label ?org_en
-          FILTER(LANG(?org_en) = "en")
-        }
+  ?org rdfs:label ?org_en
+  FILTER(LANG(?org_en) = "en")
+}
+
 OPTIONAL {
-          ?org rdfs:label ?org_et
-          FILTER(LANG(?org_et) = "et")
-        }
+  ?org rdfs:label ?org_et
+  FILTER(LANG(?org_et) = "et")
+}
+
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   OPTIONAL {
-          ?item rdfs:label ?name_en
-          FILTER(LANG(?name_en) = "en")
-        }
+  ?item rdfs:label ?name_en
+  FILTER(LANG(?name_en) = "en")
+}
+
 OPTIONAL {
-          ?item rdfs:label ?name_et
-          FILTER(LANG(?name_et) = "et")
-        }
+  ?item rdfs:label ?name_et
+  FILTER(LANG(?name_et) = "et")
+}
+
   ?statement ps:P39 ?role .
   OPTIONAL {
-          ?role rdfs:label ?role_en
-          FILTER(LANG(?role_en) = "en")
-        }
+  ?role rdfs:label ?role_en
+  FILTER(LANG(?role_en) = "en")
+}
+
 OPTIONAL {
-          ?role rdfs:label ?role_et
-          FILTER(LANG(?role_et) = "et")
-        }
+  ?role rdfs:label ?role_et
+  FILTER(LANG(?role_et) = "et")
+}
+
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_en
-          FILTER(LANG(?role_superclass_en) = "en")
-        }
+  ?role_superclass rdfs:label ?role_superclass_en
+  FILTER(LANG(?role_superclass_en) = "en")
+}
+
 OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_et
-          FILTER(LANG(?role_superclass_et) = "et")
-        }
+  ?role_superclass rdfs:label ?role_superclass_et
+  FILTER(LANG(?role_superclass_et) = "et")
+}
+
   ?role wdt:P361 ?org .
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
-          ?district rdfs:label ?district_name_en
-          FILTER(LANG(?district_name_en) = "en")
-        }
+  ?district rdfs:label ?district_name_en
+  FILTER(LANG(?district_name_en) = "en")
+}
+
 OPTIONAL {
-          ?district rdfs:label ?district_name_et
-          FILTER(LANG(?district_name_et) = "et")
-        }
+  ?district rdfs:label ?district_name_et
+  FILTER(LANG(?district_name_et) = "et")
+}
+
   }
   OPTIONAL { ?statement pq:P580 ?start }
   OPTIONAL { ?statement pq:P582 ?end }
@@ -68,13 +79,15 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
-          ?party rdfs:label ?party_name_en
-          FILTER(LANG(?party_name_en) = "en")
-        }
+  ?party rdfs:label ?party_name_en
+  FILTER(LANG(?party_name_en) = "en")
+}
+
 OPTIONAL {
-          ?party rdfs:label ?party_name_et
-          FILTER(LANG(?party_name_et) = "et")
-        }
+  ?party rdfs:label ?party_name_et
+  FILTER(LANG(?party_name_et) = "et")
+}
+
     OPTIONAL { ?party_statement pq:P582 ?end_party }
     BIND(COALESCE(?end_party, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?party_end_or_sentinel)
     FILTER(?party_end_or_sentinel >= NOW())

--- a/legislative/Q217799/Q20530392/popolo-m17n.json
+++ b/legislative/Q217799/Q20530392/popolo-m17n.json
@@ -2485,6 +2485,10 @@
         {
           "note": "facebook",
           "url": "https://www.facebook.com/vilja.toomast"
+        },
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/vilja.toomast"
         }
       ]
     },
@@ -2834,7 +2838,7 @@
       ],
       "area_id": "Q191",
       "seat_counts": {
-        "Q33129158": "101"
+        "Q21100241": "101"
       }
     },
     {
@@ -2974,7 +2978,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -2999,7 +3003,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3024,7 +3028,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3049,7 +3053,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3074,7 +3078,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3099,7 +3103,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3124,7 +3128,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3149,7 +3153,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3174,7 +3178,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3199,7 +3203,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3224,7 +3228,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3249,7 +3253,7 @@
         }
       ],
       "associated_wikidata_positions": [
-        "Q33129158"
+        "Q21100241"
       ],
       "type": {
         "lang:en": "constituency",
@@ -3271,15 +3275,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-04-09",
       "end_date": "2015-07-15",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3289,15 +3293,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3308,15 +3312,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3326,15 +3330,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3344,15 +3348,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3363,15 +3367,15 @@
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3381,15 +3385,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3399,15 +3403,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3417,15 +3421,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3435,15 +3439,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3453,15 +3457,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3471,15 +3475,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3489,15 +3493,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3508,15 +3512,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-04-09",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3526,15 +3530,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2016-11-25",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3545,15 +3549,15 @@
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
       "end_date": "2015-09-14",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3563,15 +3567,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2018-05-03",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3581,15 +3585,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3600,15 +3604,15 @@
       "area_id": "Q2972997",
       "start_date": "2015-09-16",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3619,15 +3623,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2015-04-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3638,15 +3642,15 @@
       "area_id": "Q3032626",
       "start_date": "2015-04-09",
       "end_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3656,15 +3660,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3674,15 +3678,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3692,15 +3696,15 @@
       "organization_id": "Q217799",
       "start_date": "2017-06-01",
       "end_date": "2017-06-02",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3710,15 +3714,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3729,15 +3733,15 @@
       "area_id": "Q3038253",
       "start_date": "2015-04-09",
       "end_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3747,15 +3751,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-04-09",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3765,15 +3769,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3784,15 +3788,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
       "end_date": "2016-07-06",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3803,15 +3807,15 @@
       "area_id": "Q3338787",
       "start_date": "2015-04-09",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3821,15 +3825,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-04-09",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3840,15 +3844,15 @@
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
       "end_date": "2016-06-07",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3859,15 +3863,15 @@
       "area_id": "Q2972997",
       "start_date": "2015-09-15",
       "end_date": "2015-09-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3877,15 +3881,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-11-21",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3895,15 +3899,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-08-18",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3914,15 +3918,15 @@
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
       "end_date": "2015-11-18",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3932,15 +3936,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3950,15 +3954,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3968,15 +3972,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -3987,15 +3991,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
       "end_date": "2016-12-05",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4006,15 +4010,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2018-05-06",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4024,15 +4028,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3485728",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4042,15 +4046,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4061,15 +4065,15 @@
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
       "end_date": "2016-12-10",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4079,15 +4083,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4097,15 +4101,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3038253",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4115,15 +4119,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4134,15 +4138,15 @@
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
       "end_date": "2015-03-27",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4153,15 +4157,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4172,15 +4176,15 @@
       "area_id": "Q3038253",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4191,15 +4195,15 @@
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
       "end_date": "2015-03-27",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4209,15 +4213,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4227,15 +4231,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4246,15 +4250,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2015-11-20",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4265,15 +4269,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2017-06-01",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4284,15 +4288,15 @@
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
       "end_date": "2017-11-07",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4302,15 +4306,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3485728",
       "start_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4321,15 +4325,15 @@
       "area_id": "Q3485728",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4340,15 +4344,15 @@
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4358,15 +4362,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4376,15 +4380,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4394,15 +4398,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4412,15 +4416,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4430,15 +4434,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3038253",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4448,15 +4452,15 @@
       "organization_id": "Q217799",
       "start_date": "2017-11-08",
       "end_date": "2018-05-02",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4466,15 +4470,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4484,15 +4488,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4503,15 +4507,15 @@
       "area_id": "Q3485728",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4521,15 +4525,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4540,15 +4544,15 @@
       "area_id": "Q2420663",
       "start_date": "2016-12-05",
       "end_date": "2016-12-06",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4558,15 +4562,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4577,15 +4581,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4595,15 +4599,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4613,15 +4617,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2017-06-02",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4631,15 +4635,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4650,15 +4654,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-04-09",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4668,15 +4672,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4687,15 +4691,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2017-11-10",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4705,15 +4709,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4723,15 +4727,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4741,15 +4745,15 @@
       "organization_id": "Q217799",
       "start_date": "2015-09-15",
       "end_date": "2015-09-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4759,15 +4763,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4778,15 +4782,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
       "end_date": "2016-09-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4796,15 +4800,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4814,15 +4818,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4832,15 +4836,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4850,15 +4854,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4868,15 +4872,15 @@
       "organization_id": "Q217799",
       "start_date": "2016-11-24",
       "end_date": "2016-11-25",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4886,15 +4890,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4904,15 +4908,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4922,15 +4926,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4941,15 +4945,15 @@
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
       "end_date": "2015-09-14",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4960,15 +4964,15 @@
       "area_id": "Q3485728",
       "start_date": "2015-04-09",
       "end_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4978,15 +4982,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -4997,15 +5001,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5015,15 +5019,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5033,15 +5037,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5051,15 +5055,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5069,15 +5073,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2016-12-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5087,15 +5091,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5106,15 +5110,15 @@
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
       "end_date": "2018-04-04",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5124,15 +5128,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5142,15 +5146,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5161,15 +5165,15 @@
       "area_id": "Q3142965",
       "start_date": "2016-07-07",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5179,15 +5183,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2018-05-07",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5197,15 +5201,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5215,15 +5219,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5233,15 +5237,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-04-27",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5251,15 +5255,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5270,15 +5274,15 @@
       "area_id": "Q3142965",
       "start_date": "2015-04-09",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5288,15 +5292,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3038253",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5306,15 +5310,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5325,15 +5329,15 @@
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5343,15 +5347,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2016-12-10",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5362,15 +5366,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5381,15 +5385,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-09-15",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5399,15 +5403,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5418,15 +5422,15 @@
       "area_id": "Q3032626",
       "start_date": "2016-09-13",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5436,15 +5440,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-11-19",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5455,15 +5459,15 @@
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
       "end_date": "2015-08-31",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5473,15 +5477,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2016-06-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5492,15 +5496,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5510,15 +5514,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2016-12-11",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5529,15 +5533,15 @@
       "area_id": "Q3038253",
       "start_date": "2016-11-24",
       "end_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5547,15 +5551,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2016-12-06",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5566,15 +5570,15 @@
       "area_id": "Q3352911",
       "start_date": "2016-12-10",
       "end_date": "2016-12-11",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5584,15 +5588,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3485728",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5602,15 +5606,15 @@
       "organization_id": "Q217799",
       "start_date": "2016-11-24",
       "end_date": "2016-12-09",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5620,15 +5624,15 @@
       "organization_id": "Q217799",
       "start_date": "2016-11-23",
       "end_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5639,15 +5643,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2016-12-15",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5658,15 +5662,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2015-08-05",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5676,15 +5680,16 @@
       "organization_id": "Q217799",
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "end_date": "2018-06-15",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5694,15 +5699,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3032626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5713,15 +5718,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-04-09",
       "end_date": "2015-09-14",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5731,15 +5736,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2016-11-24",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5749,15 +5754,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5768,15 +5773,15 @@
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5786,15 +5791,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5804,15 +5809,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5823,15 +5828,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5841,15 +5846,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5859,15 +5864,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3479058",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5878,15 +5883,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
       "end_date": "2015-03-27",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5897,15 +5902,15 @@
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5915,15 +5920,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5933,15 +5938,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5951,15 +5956,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-07-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -5970,15 +5975,32 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q460589-3a26eeca-46cd-d5da-2885-efcb1839eaf1",
+      "person_id": "Q460589",
+      "on_behalf_of_id": "Q738947",
+      "organization_id": "Q217799",
+      "start_date": "2018-06-15",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
       },
-      "role_code": "Q33129158",
+      "role_code": "Q21100241",
       "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
+        "lang:en": "member of the Estonian Riigikogu",
+        "lang:et": "Riigikogu liige"
       }
     },
     {
@@ -5989,15 +6011,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-04-09",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6008,15 +6030,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6027,15 +6049,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-03-30",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6046,15 +6068,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-09-15",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6065,15 +6087,15 @@
       "area_id": "Q3413626",
       "start_date": "2015-09-15",
       "end_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6083,15 +6105,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6101,15 +6123,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2015-09-16",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6120,15 +6142,15 @@
       "area_id": "Q3402163",
       "start_date": "2015-04-09",
       "end_date": "2015-09-14",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6138,15 +6160,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2018-04-05",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6156,15 +6178,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3402163",
       "start_date": "2017-11-10",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6175,15 +6197,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
       "end_date": "2015-03-27",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6193,15 +6215,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3338787",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6212,15 +6234,15 @@
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6230,15 +6252,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6249,15 +6271,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6267,15 +6289,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3352911",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6285,15 +6307,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3038253",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6303,15 +6325,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6322,15 +6344,15 @@
       "area_id": "Q2420663",
       "start_date": "2015-09-01",
       "end_date": "2017-06-12",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6340,15 +6362,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3025278",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6358,15 +6380,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3485728",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6376,15 +6398,15 @@
       "organization_id": "Q217799",
       "area_id": "Q2972997",
       "start_date": "2015-03-30",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6395,15 +6417,15 @@
       "area_id": "Q3142965",
       "start_date": "2015-03-30",
       "end_date": "2015-04-08",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     },
     {
@@ -6413,15 +6435,15 @@
       "organization_id": "Q217799",
       "area_id": "Q3142965",
       "start_date": "2016-11-23",
-      "role_superclass_code": "Q21100241",
+      "role_superclass_code": "Q486839",
       "role_superclass": {
+        "lang:en": "member of parliament",
+        "lang:et": "Parlamendiliige"
+      },
+      "role_code": "Q21100241",
+      "role": {
         "lang:en": "member of the Estonian Riigikogu",
         "lang:et": "Riigikogu liige"
-      },
-      "role_code": "Q33129158",
-      "role": {
-        "lang:en": "Member of the 13th Riigikogu",
-        "lang:et": "XIII Riigikogu liige"
       }
     }
   ]

--- a/legislative/Q217799/Q20530392/query-results.json
+++ b/legislative/Q217799/Q20530392/query-results.json
@@ -38,31 +38,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -146,31 +146,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -249,31 +249,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -361,31 +361,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -468,31 +468,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -580,31 +580,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -687,31 +687,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -790,31 +790,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -897,31 +897,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1004,31 +1004,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1107,31 +1107,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1214,31 +1214,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1321,31 +1321,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1428,31 +1428,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1540,31 +1540,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1647,31 +1647,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1755,31 +1755,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1858,31 +1858,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -1965,31 +1965,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2073,31 +2073,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2181,31 +2181,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2293,31 +2293,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2396,31 +2396,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2489,31 +2489,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2601,31 +2601,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2704,31 +2704,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2812,31 +2812,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -2919,31 +2919,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3026,31 +3026,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3134,31 +3134,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3246,31 +3246,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3353,31 +3353,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3461,31 +3461,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3569,31 +3569,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3676,31 +3676,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3783,31 +3783,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3891,31 +3891,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -3998,31 +3998,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4105,31 +4105,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4212,31 +4212,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4320,31 +4320,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4432,31 +4432,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4539,31 +4539,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4646,31 +4646,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4754,31 +4754,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4861,31 +4861,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -4968,31 +4968,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5075,31 +5075,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5183,31 +5183,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5295,31 +5295,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5407,31 +5407,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5515,31 +5515,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5622,31 +5622,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5729,31 +5729,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5837,31 +5837,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -5949,31 +5949,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6061,31 +6061,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6173,31 +6173,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6280,31 +6280,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6392,31 +6392,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6499,31 +6499,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6606,31 +6606,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6713,31 +6713,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6820,31 +6820,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -6913,31 +6913,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7025,31 +7025,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7132,31 +7132,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7239,31 +7239,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7347,31 +7347,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7454,31 +7454,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7562,31 +7562,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7674,31 +7674,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7781,31 +7781,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7888,31 +7888,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -7995,31 +7995,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8102,31 +8102,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8214,31 +8214,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8321,31 +8321,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8433,31 +8433,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8540,31 +8540,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8633,31 +8633,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8745,31 +8745,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8852,31 +8852,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -8964,31 +8964,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9071,31 +9071,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9178,31 +9178,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9285,31 +9285,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9378,31 +9378,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9486,31 +9486,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9593,31 +9593,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9700,31 +9700,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9807,31 +9807,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -9919,31 +9919,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10026,31 +10026,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10138,31 +10138,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10250,31 +10250,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10357,31 +10357,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10464,31 +10464,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10571,31 +10571,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10678,31 +10678,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10785,31 +10785,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -10892,31 +10892,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11004,31 +11004,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11111,31 +11111,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11218,31 +11218,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11326,31 +11326,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11429,31 +11429,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11532,31 +11532,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11639,31 +11639,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11746,31 +11746,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11853,31 +11853,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -11965,31 +11965,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12072,31 +12072,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12175,31 +12175,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12287,31 +12287,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12394,31 +12394,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12506,31 +12506,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12618,31 +12618,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12725,31 +12725,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12837,31 +12837,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -12944,31 +12944,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13052,31 +13052,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13159,31 +13159,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13271,31 +13271,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13378,31 +13378,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13490,31 +13490,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13597,31 +13597,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13705,31 +13705,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13794,31 +13794,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -13892,31 +13892,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14000,31 +14000,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14107,31 +14107,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14219,31 +14219,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14287,6 +14287,11 @@
         "type" : "literal",
         "value" : "2015-03-30T00:00:00Z"
       },
+      "end" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-15T00:00:00Z"
+      },
       "facebook" : {
         "type" : "literal",
         "value" : "eerik.kross"
@@ -14326,31 +14331,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14429,31 +14434,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14541,31 +14546,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14648,31 +14653,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14760,31 +14765,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14867,31 +14872,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -14970,31 +14975,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15077,31 +15082,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15189,31 +15194,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15296,31 +15301,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15403,31 +15408,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15511,31 +15516,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15619,31 +15624,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15726,31 +15731,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15833,31 +15838,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -15945,31 +15950,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16052,31 +16057,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16132,6 +16137,99 @@
     }, {
       "party" : {
         "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q738947"
+      },
+      "party_name_et" : {
+        "xml:lang" : "et",
+        "type" : "literal",
+        "value" : "Eesti Reformierakond"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Estonian Reform Party"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q460589-3a26eeca-46cd-d5da-2885-efcb1839eaf1"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_et" : {
+        "xml:lang" : "et",
+        "type" : "literal",
+        "value" : "Parlamendiliige"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q21100241"
+      },
+      "role_et" : {
+        "xml:lang" : "et",
+        "type" : "literal",
+        "value" : "Riigikogu liige"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of the Estonian Riigikogu"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q460589"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Vilja Toomast"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q217799"
+      },
+      "org_et" : {
+        "xml:lang" : "et",
+        "type" : "literal",
+        "value" : "Riigikogu"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Riigikogu"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q191"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "101"
+      },
+      "name_et" : {
+        "xml:lang" : "et",
+        "type" : "literal",
+        "value" : "Vilja Toomast"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2018-06-15T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "vilja.toomast"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q913551"
       },
       "party_name_et" : {
@@ -16164,31 +16262,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16276,31 +16374,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16388,31 +16486,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16500,31 +16598,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16612,31 +16710,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16719,31 +16817,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16831,31 +16929,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -16938,31 +17036,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17036,31 +17134,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17134,31 +17232,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17241,31 +17339,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17349,31 +17447,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17452,31 +17550,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17560,31 +17658,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17667,31 +17765,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17774,31 +17872,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17881,31 +17979,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -17993,31 +18091,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -18100,31 +18198,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -18207,31 +18305,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -18314,31 +18412,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -18426,31 +18524,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",
@@ -18533,31 +18631,31 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q21100241"
+        "value" : "http://www.wikidata.org/entity/Q486839"
       },
       "role_superclass_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "Riigikogu liige"
+        "value" : "Parlamendiliige"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "member of the Estonian Riigikogu"
+        "value" : "member of parliament"
       },
       "role" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q33129158"
+        "value" : "http://www.wikidata.org/entity/Q21100241"
       },
       "role_et" : {
         "xml:lang" : "et",
         "type" : "literal",
-        "value" : "XIII Riigikogu liige"
+        "value" : "Riigikogu liige"
       },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "Member of the 13th Riigikogu"
+        "value" : "member of the Estonian Riigikogu"
       },
       "item" : {
         "type" : "uri",

--- a/legislative/Q217799/Q20530392/query-used.rq
+++ b/legislative/Q217799/Q20530392/query-used.rq
@@ -7,51 +7,61 @@ SELECT ?statement
        ?start ?end ?facebook
        ?org ?org_en ?org_et ?org_jurisdiction ?org_seat_count
 WHERE {
-  BIND(wd:Q33129158 as ?role) .
+  BIND(wd:Q21100241 as ?role) .
+  BIND(wd:Q33129158 as ?specific_role) .
   BIND(wd:Q217799 as ?org) .
   OPTIONAL {
-          ?org rdfs:label ?org_en
-          FILTER(LANG(?org_en) = "en")
-        }
+  ?org rdfs:label ?org_en
+  FILTER(LANG(?org_en) = "en")
+}
+
 OPTIONAL {
-          ?org rdfs:label ?org_et
-          FILTER(LANG(?org_et) = "et")
-        }
+  ?org rdfs:label ?org_et
+  FILTER(LANG(?org_et) = "et")
+}
+
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
   OPTIONAL {
     ?org wdt:P1342 ?org_seat_count
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   OPTIONAL {
-          ?item rdfs:label ?name_en
-          FILTER(LANG(?name_en) = "en")
-        }
+  ?item rdfs:label ?name_en
+  FILTER(LANG(?name_en) = "en")
+}
+
 OPTIONAL {
-          ?item rdfs:label ?name_et
-          FILTER(LANG(?name_et) = "et")
-        }
-  ?statement ps:P39 ?role .
+  ?item rdfs:label ?name_et
+  FILTER(LANG(?name_et) = "et")
+}
+
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
-          ?role rdfs:label ?role_en
-          FILTER(LANG(?role_en) = "en")
-        }
+  ?role rdfs:label ?role_en
+  FILTER(LANG(?role_en) = "en")
+}
+
 OPTIONAL {
-          ?role rdfs:label ?role_et
-          FILTER(LANG(?role_et) = "et")
-        }
+  ?role rdfs:label ?role_et
+  FILTER(LANG(?role_et) = "et")
+}
+
   OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_en
-          FILTER(LANG(?role_superclass_en) = "en")
-        }
+  ?role_superclass rdfs:label ?role_superclass_en
+  FILTER(LANG(?role_superclass_en) = "en")
+}
+
 OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_et
-          FILTER(LANG(?role_superclass_et) = "et")
-        }
+  ?role_superclass rdfs:label ?role_superclass_et
+  FILTER(LANG(?role_superclass_et) = "et")
+}
+
   }
   ?statement pq:P2937 wd:Q20530392 .
   OPTIONAL { ?statement pq:P580 ?start }
@@ -59,24 +69,28 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
-          ?district rdfs:label ?district_name_en
-          FILTER(LANG(?district_name_en) = "en")
-        }
+  ?district rdfs:label ?district_name_en
+  FILTER(LANG(?district_name_en) = "en")
+}
+
 OPTIONAL {
-          ?district rdfs:label ?district_name_et
-          FILTER(LANG(?district_name_et) = "et")
-        }
+  ?district rdfs:label ?district_name_et
+  FILTER(LANG(?district_name_et) = "et")
+}
+
   }
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
-          ?party rdfs:label ?party_name_en
-          FILTER(LANG(?party_name_en) = "en")
-        }
+  ?party rdfs:label ?party_name_en
+  FILTER(LANG(?party_name_en) = "en")
+}
+
 OPTIONAL {
-          ?party rdfs:label ?party_name_et
-          FILTER(LANG(?party_name_et) = "et")
-        }
+  ?party rdfs:label ?party_name_et
+  FILTER(LANG(?party_name_et) = "et")
+}
+
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   

--- a/legislative/Q4145632/Q53998275/query-used.rq
+++ b/legislative/Q4145632/Q53998275/query-used.rq
@@ -8,50 +8,60 @@ SELECT ?statement
        ?org ?org_en ?org_et ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53997936 as ?role) .
+  BIND(wd:Q53997936 as ?specific_role) .
   BIND(wd:Q4145632 as ?org) .
   OPTIONAL {
-          ?org rdfs:label ?org_en
-          FILTER(LANG(?org_en) = "en")
-        }
+  ?org rdfs:label ?org_en
+  FILTER(LANG(?org_en) = "en")
+}
+
 OPTIONAL {
-          ?org rdfs:label ?org_et
-          FILTER(LANG(?org_et) = "et")
-        }
+  ?org rdfs:label ?org_et
+  FILTER(LANG(?org_et) = "et")
+}
+
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
   OPTIONAL {
     ?org wdt:P1342 ?org_seat_count
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   OPTIONAL {
-          ?item rdfs:label ?name_en
-          FILTER(LANG(?name_en) = "en")
-        }
+  ?item rdfs:label ?name_en
+  FILTER(LANG(?name_en) = "en")
+}
+
 OPTIONAL {
-          ?item rdfs:label ?name_et
-          FILTER(LANG(?name_et) = "et")
-        }
-  ?statement ps:P39 ?role .
+  ?item rdfs:label ?name_et
+  FILTER(LANG(?name_et) = "et")
+}
+
+  ?statement ps:P39 ?specific_role .
   OPTIONAL {
-          ?role rdfs:label ?role_en
-          FILTER(LANG(?role_en) = "en")
-        }
+  ?role rdfs:label ?role_en
+  FILTER(LANG(?role_en) = "en")
+}
+
 OPTIONAL {
-          ?role rdfs:label ?role_et
-          FILTER(LANG(?role_et) = "et")
-        }
+  ?role rdfs:label ?role_et
+  FILTER(LANG(?role_et) = "et")
+}
+
   OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_en
-          FILTER(LANG(?role_superclass_en) = "en")
-        }
+  ?role_superclass rdfs:label ?role_superclass_en
+  FILTER(LANG(?role_superclass_en) = "en")
+}
+
 OPTIONAL {
-          ?role_superclass rdfs:label ?role_superclass_et
-          FILTER(LANG(?role_superclass_et) = "et")
-        }
+  ?role_superclass rdfs:label ?role_superclass_et
+  FILTER(LANG(?role_superclass_et) = "et")
+}
+
   }
   ?statement pq:P2937 wd:Q53998275 .
   OPTIONAL { ?statement pq:P580 ?start }
@@ -59,24 +69,28 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
-          ?district rdfs:label ?district_name_en
-          FILTER(LANG(?district_name_en) = "en")
-        }
+  ?district rdfs:label ?district_name_en
+  FILTER(LANG(?district_name_en) = "en")
+}
+
 OPTIONAL {
-          ?district rdfs:label ?district_name_et
-          FILTER(LANG(?district_name_et) = "et")
-        }
+  ?district rdfs:label ?district_name_et
+  FILTER(LANG(?district_name_et) = "et")
+}
+
   }
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
-          ?party rdfs:label ?party_name_en
-          FILTER(LANG(?party_name_en) = "en")
-        }
+  ?party rdfs:label ?party_name_en
+  FILTER(LANG(?party_name_en) = "en")
+}
+
 OPTIONAL {
-          ?party rdfs:label ?party_name_et
-          FILTER(LANG(?party_name_et) = "et")
-        }
+  ?party rdfs:label ?party_name_et
+  FILTER(LANG(?party_name_et) = "et")
+}
+
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   

--- a/legislative/index-query-used.rq
+++ b/legislative/index-query-used.rq
@@ -1,29 +1,32 @@
-SELECT DISTINCT ?legislature ?legislatureLabel ?country ?countryLabel ?adminArea ?adminAreaLabel ?adminAreaType ?adminAreaTypeLabel ?legislaturePost ?legislaturePostLabel ?numberOfSeats WHERE {
+SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?adminAreaTypes ?legislaturePost ?legislaturePostLabel ?numberOfSeats WHERE {
   {
-    SELECT DISTINCT ?primarySort ?adminArea ?adminAreaType {
+    SELECT DISTINCT ?adminArea
+                (MIN(?primarySort) AS ?primarySort)
+                (GROUP_CONCAT(DISTINCT REPLACE(STR(?adminAreaType), '^.*/', ''); SEPARATOR=" ") AS ?adminAreaTypes) {
   {
     VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:Q191 1 wd:Q6256) }
   } UNION {
-    # Find FLACSen of this country
+    # Find regional admin areas of this country (generally FLACSen)
     ?adminArea wdt:P17 wd:Q191 ;
           wdt:P31/wdt:P279* wd:Q10864048
     VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
   } UNION {
-    # Find cities with populations of over 250k
+    # Find cities or municipalities with populations of over 250k
+    VALUES ?adminAreaType { wd:Q515 wd:Q15284 }
     ?adminArea wdt:P17 wd:Q191 ;
-       wdt:P31/wdt:P279* wd:Q515 ;
+       wdt:P31/wdt:P279* ?adminAreaType ;
        wdt:P1082 ?population .
     FILTER (?population > 250000)
-    # Make sure the city is not also a FLACS
-    MINUS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
-    VALUES (?primarySort ?adminAreaType) { (3 wd:Q515) }
+    VALUES ?primarySort { 3 }
   } UNION {
-  VALUES (?adminArea ?primarySort ?adminAreaType) {
-    (wd:Q4450503 4 wd:Q24238356)
+    VALUES (?adminArea ?primarySort ?adminAreaType) {
+      (wd:Q4450503 4 wd:Q24238356)
+    }
   }
-}
 
-} ORDER BY ?primarySort
+  # Remove admin areas that have ended
+  FILTER NOT EXISTS { ?adminArea wdt:P582|wdt:P576 ?adminAreaEnd . FILTER (?adminAreaEnd < NOW()) }
+} GROUP BY ?adminArea ORDER BY ?primarySort ?adminArea
 
   }
 
@@ -51,4 +54,4 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?country ?countryLabel ?adminArea
   # Remove legislatures that have ended
   FILTER NOT EXISTS { ?legislature wdt:P576 ?legislatureEnd . FILTER (?legislatureEnd < NOW()) }
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en,et". }
-} ORDER BY ?primarySort ?country ?adminAreaType ?legislature ?legislaturePost
+} ORDER BY ?primarySort ?legislature ?legislaturePost

--- a/legislative/index-terms-query-used.rq
+++ b/legislative/index-terms-query-used.rq
@@ -1,5 +1,14 @@
-SELECT DISTINCT ?house ?houseLabel ?legislature ?legislatureLabel ?term ?termLabel ?termStart ?termEnd WHERE {
-  VALUES ?house { wd:Q217799 wd:Q4145632 }
+SELECT DISTINCT
+  ?house ?houseLabel
+  ?legislature ?legislatureLabel
+  ?term ?termLabel
+  ?termStart ?termEnd
+  ?termSpecificPosition
+WHERE {
+  VALUES (?house ?position) {
+    (wd:Q217799 wd:Q21100241)
+    (wd:Q4145632 wd:Q53997936)
+  }
   ?house (p:P361/ps:P361)* ?legislature .
       ?baseTerm p:P31|p:P279 [ ps:P279|ps:P31 wd:Q15238777 ; pq:P642 ?legislature ] .
       OPTIONAL { ?subTerm wdt:P31 ?baseTerm }
@@ -10,6 +19,11 @@ SELECT DISTINCT ?house ?houseLabel ?legislature ?legislatureLabel ?term ?termLab
   OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd. }
   OPTIONAL { ?term (wdt:P155|wdt:P1365) ?termReplaces }
   OPTIONAL { ?term (wdt:P156|wdt:P1366) ?termReplacedBy }
+  OPTIONAL {
+    ?termSpecificPosition wdt:P31/wdt:P279* wd:Q4164871 ;
+                          p:P279 [ ps:P279 ?position ;
+                                   pq:P2937 ?term ] .
+  }
 
   FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
   FILTER (!BOUND(?termReplacedBy))

--- a/legislative/index.json
+++ b/legislative/index.json
@@ -2,10 +2,11 @@
   {
     "comment": "Riigikogu",
     "house_item_id": "Q217799",
-    "position_item_id": "Q33129158",
+    "position_item_id": "Q21100241",
     "terms": [
       {
         "comment": "13th Riigikogu",
+        "position_item_id": "Q33129158",
         "term_item_id": "Q20530392"
       }
     ]


### PR DESCRIPTION
This follows changes in commons-builder to hide the term-specific position ID
from outputs: everypolitician/commons-builder@0cba06a

This PR rebuilds the legislative index to include the term-specific ID, updates the boundaries index to use the generic ID, and refreshes and then rebuilds the data.

There's something up with the executive index that's causing a duplicated entry for mayor of Tallinn, which would be best dealt with in a separate PR. Once that's done, this repo will be building cleanly.